### PR TITLE
Fixes old hardcoded db name 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "scripts"]
+	path = scripts
+	url = ssh://ubuntu@ec2-18-185-76-239.eu-central-1.compute.amazonaws.com/home/ubuntu/git/scripts

--- a/sarafu_user_db_test.py
+++ b/sarafu_user_db_test.py
@@ -725,7 +725,7 @@ def get_user_info(conn,private=False):
 if dbpass == None:
     conn = psycopg2.connect(
             f"""
-            dbname=postgres
+            dbname=sarafu_app
             user={dbuser}
             host={dbname}
             """)
@@ -739,7 +739,7 @@ if dbpass == None:
 else:
     conn = psycopg2.connect(
             f"""
-            dbname=postgres
+            dbname=sarafu_app
             user={dbuser}
             host={dbname}
             password={dbpass}

--- a/sarafu_ussd_db_test.py
+++ b/sarafu_ussd_db_test.py
@@ -34,7 +34,7 @@ dbuser=os.environ.get('DBUSER')
 
 conn = psycopg2.connect(
         f"""
-        dbname=postgres
+        dbname=sarafu_app
         user={dbuser}
         host={dbname}
         """)


### PR DESCRIPTION
The name `postgres` is no longer valid with new servers.